### PR TITLE
Small improvement to finding separatrix

### DIFF
--- a/freegs/critical.py
+++ b/freegs/critical.py
@@ -24,7 +24,9 @@ along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
 from scipy import interpolate
 from numpy import zeros
 from numpy.linalg import inv
-from numpy import dot, linspace, argmax, argmin, abs, clip, sin, cos, pi, amax
+from numpy import dot, linspace, argmax, argmin, abs, clip, sin, cos, pi, amax, arctan2
+from warnings import warn
+
 
 def find_critical(R, Z, psi,discard_xpoints=False):
     """
@@ -359,29 +361,61 @@ def find_psisurface(eq, psifunc, r0,z0, r1,z1, psival=1.0, n=100, axis=None):
     
     return r,z
 
+
 def find_separatrix(eq, opoint=None, xpoint=None, ntheta=20, psi=None, axis=None):
-    """
-    
+    """Find the R, Z coordinates of the separatrix for equilbrium
+    eq. Returns a tuple of (R, Z, R_X, Z_X), where R_X, Z_X are the
+    coordinates of the X-point on the separatrix. Points are equally
+    spaced in geometric poloidal angle.
+
+    If opoint, xpoint or psi are not given, they are calculated from eq
+
+    eq - Equilibrium object
+    opoint - List of O-point tuples of (R, Z, psi)
+    xpoint - List of X-point tuples of (R, Z, psi)
+    ntheta - Number of points to find
+    psi - Grid of psi on (R, Z)
+    axis - A matplotlib axis object to plot points on
     """
     if psi is None:
         psi = eq.psi()
-        
+
     if (opoint is None) or (xpoint is None):
         opoint, xpoint = find_critical(eq.R, eq.Z, psi)
-    
+
     psinorm = (psi - opoint[0][2])/(xpoint[0][2] - opoint[0][2])
     
     psifunc = interpolate.RectBivariateSpline(eq.R[:,0], eq.Z[0,:], psinorm)
 
+    r0, z0 = opoint[0][0:2]
+
+    theta_grid = linspace(0, 2*pi, ntheta, endpoint=False)
+    dtheta = theta_grid[1] - theta_grid[0]
+
+    # Avoid putting theta grid points exactly on the X-points
+    xpoint_thetas = [arctan2(r - r0, z - z0) for r, z, _ in xpoint]
+    # Maximum number of times to adjust the grid before giving up
+    MAX_ITERATIONS = 10
+    # How close in theta to allow theta grid points to an X-point
+    TOLERANCE = 1.e-8
+    count = 1
+    for xpoint_theta in xpoint_thetas:
+        while any(abs(theta_grid - xpoint_theta) < TOLERANCE):
+            if count > MAX_ITERATIONS:
+                message = ("Maximum number of iterations ({}) when adjusting theta grid"
+                           .format(MAX_ITERATIONS))
+                warn(message)
+                break
+            theta_grid += dtheta / 2.
+            count += 1
+
     isoflux = []
-    
-    for theta in linspace(0, 2*pi, ntheta, endpoint=False):
-        r0, z0 = opoint[0][0:2]
-        r,z = find_psisurface(eq, psifunc, 
-                              r0, z0, 
-                              r0 + 10.*sin(theta), z0 + 10.*cos(theta),
-                              psival=1.0,
-                              axis=axis)
-        isoflux.append( (r,z, xpoint[0][0], xpoint[0][1]) )
-    
+    for theta in theta_grid:
+        r, z = find_psisurface(eq, psifunc,
+                               r0, z0,
+                               r0 + 10.*sin(theta), z0 + 10.*cos(theta),
+                               psival=1.0,
+                               axis=axis)
+        isoflux.append((r, z, xpoint[0][0], xpoint[0][1]))
+
     return isoflux

--- a/freegs/critical.py
+++ b/freegs/critical.py
@@ -393,21 +393,12 @@ def find_separatrix(eq, opoint=None, xpoint=None, ntheta=20, psi=None, axis=None
     dtheta = theta_grid[1] - theta_grid[0]
 
     # Avoid putting theta grid points exactly on the X-points
-    xpoint_thetas = [arctan2(r - r0, z - z0) for r, z, _ in xpoint]
-    # Maximum number of times to adjust the grid before giving up
-    MAX_ITERATIONS = 10
-    # How close in theta to allow theta grid points to an X-point
-    TOLERANCE = 1.e-8
-    count = 1
-    for xpoint_theta in xpoint_thetas:
-        while any(abs(theta_grid - xpoint_theta) < TOLERANCE):
-            if count > MAX_ITERATIONS:
-                message = ("Maximum number of iterations ({}) when adjusting theta grid"
-                           .format(MAX_ITERATIONS))
-                warn(message)
-                break
-            theta_grid += dtheta / 2.
-            count += 1
+    xpoint_theta = arctan2(xpoint[0][0] - r0, xpoint[0][1] - z0)
+    # How close in theta to allow theta grid points to the X-point
+    TOLERANCE = 1.e-3
+    if any(abs(theta_grid - xpoint_theta) < TOLERANCE):
+        warn("Theta grid too close to X-point, shifting by half-step")
+        theta_grid += dtheta / 2
 
     isoflux = []
     for theta in theta_grid:

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -3,11 +3,12 @@ Defines class to represent the equilibrium
 state, including plasma and coil currents
 """
 
-from numpy import meshgrid, linspace, exp, zeros, nditer
+from numpy import meshgrid, linspace, exp, zeros, nditer, array
 from scipy import interpolate
 from scipy.integrate import romb, quad # Romberg integration
 
 from .boundary import fixedBoundary, freeBoundary
+from .critical import find_separatrix
 
 # Operators which define the G-S equation
 from .gradshafranov import mu0, GSsparse
@@ -239,6 +240,12 @@ class Equilibrium:
         """
         return self._profiles.pressure(psinorm)
 
+    def separatrix(self, ntheta=20):
+        """
+        Returns an array of ntheta (R, Z) coordinates of the separatrix,
+        equally spaced in geometric poloidal angle.
+        """
+        return array(find_separatrix(self, ntheta=ntheta, psi=self.psi()))[:, 0:2]
 
     def solve(self, profiles):
         """


### PR DESCRIPTION
If a theta grid point is too close to the primary X-point, `find_psisurface` may overshoot and find a surface beyond the X-point. This checks if the X-points is too close (in theta) to any of the grid points, and if so shifts the theta-grid by half the grid spacing.

An alternative is the following change:
```diff
@@ -393,21 +393,12 @@ def find_separatrix(eq, opoint=None, xpoint=None, ntheta=20, psi=None, axis=None
     dtheta = theta_grid[1] - theta_grid[0]
 
     # Avoid putting theta grid points exactly on the X-points
-    xpoint_theta = arctan2(xpoint[0][0] - r0, xpoint[0][1] - z0)
-    # How close in theta to allow theta grid points to the X-point
-    TOLERANCE = 1.e-3
-    if any(abs(theta_grid - xpoint_theta) < TOLERANCE):
-        warn("Theta grid too close to X-point, shifting by half-step")
-        theta_grid += dtheta / 2
+    xpoint_thetas = [arctan2(r - r0, z - z0) for r, z, _ in xpoint]
+    # Maximum number of times to adjust the grid before giving up
+    MAX_ITERATIONS = 10
+    # How close in theta to allow theta grid points to an X-point
+    TOLERANCE = 1.e-8
+    count = 1
+    for xpoint_theta in xpoint_thetas:
+        while any(abs(theta_grid - xpoint_theta) < TOLERANCE):
+            if count > MAX_ITERATIONS:
+                message = ("Maximum number of iterations ({}) when adjusting theta grid"
+                           .format(MAX_ITERATIONS))
+                warn(message)
+                break
+            theta_grid += dtheta / (MAX_ITERATIONS - 1)
+            count += 1
 
     isoflux = []
```
which tries to check all the X-points and just shift the grid by a small amount, but it still fails for some cases.

An even better solution may be trying to work out if a point has overshot and then just replacing it with the X-point itself. This might be tricky to do and still keep the grid equally-spaced though.