### PR TITLE
Save/restore Equilibrium to/from HDF5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.pkl
 *.geqdsk
 *.pdf
+*.h5
 

--- a/freegs/__init__.py
+++ b/freegs/__init__.py
@@ -40,3 +40,4 @@ from . import control
 
 from .picard import solve
 
+from .dump import OutputFile

--- a/freegs/dump.py
+++ b/freegs/dump.py
@@ -1,0 +1,96 @@
+# Py2/3 compatibility
+from __future__ import unicode_literals
+from builtins import str
+
+import h5py
+import numpy as np
+
+from .equilibrium import Equilibrium
+from .machine import Coil, Circuit, Machine
+
+string_dtype = h5py.special_dtype(vlen=str)
+
+coil_dtype = np.dtype([
+    (("R", "Major radius"), np.float64),
+    (("Z", "Vertical position"), np.float64),
+    (("current", "Current (Amps)"), np.float64),
+    (("control", "Use feedback control?"), np.bool),
+])
+
+circuit_dtype = np.dtype([
+    (("label", "Coil label"), string_dtype),
+    (("R", "Major radius"), np.float64),
+    (("Z", "Vertical position"), np.float64),
+    (("current", "Current (Amps)"), np.float64),
+    (("control", "Use feedback control?"), np.bool),
+    (("multiplier", "Mupltiplication factor for current"), np.float64),
+])
+
+solenoid_dtype = np.dtype([
+    (("Rs", "Radius"), np.float64),
+    (("Zsmin", "Minimum Z"), np.float64),
+    (("Zsmax", "Maximum Z"), np.float64),
+    (("Ns", "Number of turns"), np.float64),
+    (("current", "Current (Amps)"), np.float64),
+    (("control", "Use feedback control?"), np.bool),
+])
+
+
+def dump_equilibrium(equilibrium, filename):
+    with h5py.File(filename, 'w') as dumpfile:
+        dumpfile["coil_dtype"] = coil_dtype
+        coil_dtype_id = dumpfile["coil_dtype"]
+
+        dumpfile["circuit_dtype"] = circuit_dtype
+        circuit_dtype_id = dumpfile["circuit_dtype"]
+
+        dumpfile["solenoid_dtype"] = solenoid_dtype
+        solenoid_dtype_id = dumpfile["solenoid_dtype"]
+
+        dumpfile.create_dataset("Rmin", data=equilibrium.Rmin)
+        dumpfile.create_dataset("Rmax", data=equilibrium.Rmax)
+        dumpfile.create_dataset("R", data=equilibrium.R)
+
+        dumpfile.create_dataset("Zmin", data=equilibrium.Zmin)
+        dumpfile.create_dataset("Zmax", data=equilibrium.Zmax)
+        dumpfile.create_dataset("Z", data=equilibrium.Z)
+
+        dumpfile.create_dataset("current", data=equilibrium.plasmaCurrent())
+        dumpfile["current"].attrs["title"] = u"Plasma current [Amps]"
+        dumpfile.create_dataset("psi", data=equilibrium.psi())
+
+        tokamak_group = dumpfile.create_group("tokamak")
+        coils_group = tokamak_group.create_group("coils")
+
+        tokamak_group.create_dataset("wall_R", data=equilibrium.tokamak.wall.R)
+        tokamak_group.create_dataset("wall_Z", data=equilibrium.tokamak.wall.Z)
+
+        for label, coil in equilibrium.tokamak.coils:
+            if isinstance(coil, Coil):
+                coils_group.create_dataset(
+                    label, dtype=coil_dtype_id,
+                    data=np.array((coil.R, coil.Z, coil.current, coil.control),
+                                  dtype=coil_dtype)
+                )
+            elif isinstance(coil, Solenoid):
+                coils_group.create_dataset(
+                    label, dtype=solenoid_dtype_id,
+                    data=np.array((coil.Rs, coil.Zmin, coil.Zmax, coil.Ns,
+                                   coil.current, coil.control), dtype=solenoid_dtype)
+                )
+            elif isinstance(coil, Circuit):
+                circuit_id = coils_group.create_dataset(label, dtype=circuit_dtype_id,
+                                                        shape=(len(coil.coils),))
+
+                # Store the Circuit's current/control as attributes on
+                # the dataset. The individual Coils in the Circuit
+                # have the default values (0/False). A different way
+                # of doing this might be to store the Circuit's
+                # current/control in each Coil, and when reading, use
+                # the values from the first Coil.
+                circuit_dtype_id.attrs["current"] = coil.current
+                circuit_dtype_id.attrs["control"] = coil.control
+
+                for index, (sublabel, subcoil, multiplier) in enumerate(coil.coils):
+                    circuit_id[index] = (sublabel, subcoil.R, subcoil.Z, 0.0,
+                                         False, multiplier)

--- a/freegs/dump.py
+++ b/freegs/dump.py
@@ -36,16 +36,28 @@ solenoid_dtype = np.dtype([
 ])
 
 
-def dump_equilibrium(equilibrium, filename):
-    with h5py.File(filename, 'w') as dumpfile:
-        dumpfile["coil_dtype"] = coil_dtype
-        coil_dtype_id = dumpfile["coil_dtype"]
+class OutputFile(object):
+    def __init__(self, name, mode=None, **kwds):
+        self.handle = h5py.File(name, mode, **kwds)
 
-        dumpfile["circuit_dtype"] = circuit_dtype
-        circuit_dtype_id = dumpfile["circuit_dtype"]
+    def close(self):
+        self.handle.close()
 
-        dumpfile["solenoid_dtype"] = solenoid_dtype
-        solenoid_dtype_id = dumpfile["solenoid_dtype"]
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def write_equilibrium(self, equilibrium):
+        self.handle["coil_dtype"] = coil_dtype
+        coil_dtype_id = self.handle["coil_dtype"]
+
+        self.handle["circuit_dtype"] = circuit_dtype
+        circuit_dtype_id = self.handle["circuit_dtype"]
+
+        self.handle["solenoid_dtype"] = solenoid_dtype
+        solenoid_dtype_id = self.handle["solenoid_dtype"]
 
         type_to_dtype = {
             Coil: coil_dtype_id,
@@ -53,19 +65,19 @@ def dump_equilibrium(equilibrium, filename):
             Solenoid: solenoid_dtype_id,
         }
 
-        dumpfile.create_dataset("Rmin", data=equilibrium.Rmin)
-        dumpfile.create_dataset("Rmax", data=equilibrium.Rmax)
-        dumpfile.create_dataset("R", data=equilibrium.R)
+        self.handle.create_dataset("Rmin", data=equilibrium.Rmin)
+        self.handle.create_dataset("Rmax", data=equilibrium.Rmax)
+        self.handle.create_dataset("R", data=equilibrium.R)
 
-        dumpfile.create_dataset("Zmin", data=equilibrium.Zmin)
-        dumpfile.create_dataset("Zmax", data=equilibrium.Zmax)
-        dumpfile.create_dataset("Z", data=equilibrium.Z)
+        self.handle.create_dataset("Zmin", data=equilibrium.Zmin)
+        self.handle.create_dataset("Zmax", data=equilibrium.Zmax)
+        self.handle.create_dataset("Z", data=equilibrium.Z)
 
-        dumpfile.create_dataset("current", data=equilibrium.plasmaCurrent())
-        dumpfile["current"].attrs["title"] = u"Plasma current [Amps]"
-        dumpfile.create_dataset("psi", data=equilibrium.psi())
+        self.handle.create_dataset("current", data=equilibrium.plasmaCurrent())
+        self.handle["current"].attrs["title"] = u"Plasma current [Amps]"
+        self.handle.create_dataset("psi", data=equilibrium.psi())
 
-        tokamak_group = dumpfile.create_group("tokamak")
+        tokamak_group = self.handle.create_group("tokamak")
         coils_group = tokamak_group.create_group("coils")
 
         if equilibrium.tokamak.wall is not None:
@@ -84,3 +96,37 @@ def dump_equilibrium(equilibrium, filename):
 
             coils_group.create_dataset(label, dtype=dtype,
                                        data=np.array(coil.to_tuple(), dtype=dtype))
+
+    def read_equilibrium(self):
+        coil_dtype_id = self.handle["coil_dtype"]
+        circuit_dtype_id = self.handle["circuit_dtype"]
+        solenoid_dtype_id = self.handle["solenoid_dtype"]
+
+        def make_coil(coil):
+            return Coil(coil["R"], coil["Z"], coil["current"], coil["control"])
+
+        def make_circuit(circuit):
+            return Circuit([(label, make_coil(coil), multiplier)
+                            for label, coil, multiplier in circuit],
+                           current=circuit[0][1]["current"] / circuit[0]["multiplier"],
+                           control=circuit[0][1]["control"])
+
+        def make_solenoid(solenoid):
+            return Solenoid(solenoid["Rs"], solenoid["Zsmin"], solenoid["Zsmax"],
+                            solenoid["Ns"], solenoid["current"], solenoid["control"])
+
+        dtype_to_type = {
+            coil_dtype: make_coil,
+            circuit_dtype: make_circuit,
+            solenoid_dtype: make_solenoid,
+        }
+
+        def make_thing(thing):
+            make_func = dtype_to_type[thing.dtype]
+            return make_func(thing[()])
+
+        coils = []
+        for label, coil_ in self.handle["tokamak/coils"].items():
+            coil = coil_[()]
+            coils.append((label, make_thing(coil)))
+        return coils

--- a/freegs/dump.py
+++ b/freegs/dump.py
@@ -1,4 +1,30 @@
-# Py2/3 compatibility
+"""
+Class for reading/writing freegs `Equilibrium` objects
+
+Currently just HDF5 via h5py
+
+License
+-------
+
+Copyright 2018 Ben Dudson, University of York. Email: benjamin.dudson@york.ac.uk
+
+This file is part of FreeGS.
+
+FreeGS is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FreeGS is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+# Py2/3 compatibility: h5py needs unicode for group/dataset names
 from __future__ import unicode_literals
 
 try:

--- a/freegs/dump.py
+++ b/freegs/dump.py
@@ -18,6 +18,7 @@ coil_dtype = np.dtype([
     ("R", np.float64),
     ("Z", np.float64),
     ("current", np.float64),
+    ("turns", np.int),
     ("control", np.bool),
 ])
 
@@ -166,7 +167,7 @@ class OutputFile(object):
         """
 
         def make_coil(coil):
-            return Coil(coil["R"], coil["Z"], coil["current"], coil["control"])
+            return Coil(coil["R"], coil["Z"], coil["current"], coil["turns"], coil["control"])
 
         def make_circuit(circuit):
             return Circuit([(label, make_coil(coil), multiplier)

--- a/freegs/dump.py
+++ b/freegs/dump.py
@@ -40,10 +40,43 @@ EQUILIBRIUM_GROUP_NAME = "equilbrium"
 
 
 class OutputFile(object):
+    """
+    Read/write freegs Equilibrium objects to file
+
+    Currently supports HDF5 format only
+
+    Given an Equilibrium object, eq, write to file like:
+
+    >>> with freegs.OutputFile("test_readwrite.h5", 'w') as f:
+    ...     f.write_equilibrium(eq)
+
+    Read back into an Equilibrium like so:
+
+    >>> with freegs.OutputFile("test_readwrite.h5", 'r') as f:
+    ...      eq = f.read_equilibrium()
+
+    Parameters
+    ----------
+    name : str
+           Name of file to open
+    mode : str
+           Mode string to pass to `h5py.File`, one of:
+             r  - Read-only, file must exist
+             r+ - Read-write, file must exist
+             w  - Create file, truncate if exists
+             w- - Create file, fail if exists
+             a  - Read-write if exists, create otherwise
+    **kwds
+           Other keyword arguments to pass to `h5py.File`
+    """
+
     def __init__(self, name, mode=None, **kwds):
         self.handle = h5py.File(name, mode, **kwds)
 
     def close(self):
+        """
+        Close the file
+        """
         self.handle.close()
 
     def __enter__(self):
@@ -54,7 +87,7 @@ class OutputFile(object):
 
     def write_equilibrium(self, equilibrium):
         """
-        Write equilbrium to file
+        Write `equilbrium` to file
         """
 
         self.handle["coil_dtype"] = coil_dtype
@@ -122,6 +155,11 @@ class OutputFile(object):
     def read_equilibrium(self):
         """
         Read an equilibrium from the file
+
+        Returns
+        -------
+        Equilibrium
+            A new `Equilibrium` object
         """
 
         def make_coil(coil):

--- a/freegs/dump.py
+++ b/freegs/dump.py
@@ -1,8 +1,12 @@
 # Py2/3 compatibility
 from __future__ import unicode_literals
-from builtins import str
 
-import h5py
+try:
+    import h5py
+    has_hdf5 = True
+except ImportError:
+    has_hdf5 = False
+
 import numpy as np
 
 from .equilibrium import Equilibrium
@@ -36,6 +40,13 @@ solenoid_dtype = np.dtype([
     ("current", np.float64),
     ("control", np.bool),
 ])
+class OutputFormatNotAvailableError(Exception):
+    """Raised when we couldn't import HDF5 (or some other library)
+    required for this OutputFile format
+
+    """
+    def __init__(self, file_format="HDF5"):
+        self.message = "Sorry, {} is not available!".format(file_format)
 
 
 class OutputFile(object):
@@ -75,6 +86,9 @@ class OutputFile(object):
     COILS_GROUP_NAME = "coils"
 
     def __init__(self, name, mode=None, **kwds):
+        if not has_hdf5:
+            raise OutputFormatNotAvailableError("HDF5")
+
         self.handle = h5py.File(name, mode, **kwds)
 
     def close(self):

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -24,7 +24,7 @@ along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
 
 from .gradshafranov import Greens, GreensBr, GreensBz
 
-from numpy import linspace
+from numpy import linspace, dtype
 
 class Coil:
     """
@@ -107,6 +107,12 @@ class Coil:
         
     def __repr__(self):
         return "Coil(R={0},Z={1},current={2},turns={3},control={4})".format(self.R, self.Z, self.current, self.turns, self.control)
+
+    def to_tuple(self):
+        """
+        Helper method for writing output
+        """
+        return (self.R, self.Z, self.current, self.control)
 
 
 class Circuit:
@@ -210,8 +216,14 @@ class Circuit:
         for label, coil, multiplier in self.coils:
             result += label+ ":" + str(coil)+ " "
         return result + ")"
-        
-    
+
+    def to_tuple(self):
+        """
+        Helper method for writing output
+        """
+        return [(label, coil.to_tuple(), multiplier)
+                 for label, coil, multiplier in self.coils]
+
 
 class Solenoid:
     """
@@ -303,6 +315,12 @@ class Solenoid:
 
     def __repr__(self):
         return "Solenoid(R={0},Zmin={1},Zmax={2},current={3},N={4},control={5})".format(self.Rs, self.Zsmin, self.Zsmax, self.current, self.Ns, self.control)
+
+    def to_tuple(self):
+        """
+        Helper method for writing output
+        """
+        return (self.Rs, self.Zsmin, self.Zsmax, self.Ns, self.current, self.control)
 
 
 class Wall:

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -123,7 +123,7 @@ class Coil:
         """
         Helper method for writing output
         """
-        return (self.R, self.Z, self.current, self.control)
+        return (self.R, self.Z, self.current, self.turns, self.control)
 
 
 class Circuit:

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -106,7 +106,18 @@ class Coil:
         return GreensBz(self.R,self.Z, R, Z) * self.turns
         
     def __repr__(self):
-        return "Coil(R={0},Z={1},current={2},turns={3},control={4})".format(self.R, self.Z, self.current, self.turns, self.control)
+        return ("Coil(R={0}, Z={1}, current={2}, turns={3}, control={4})"
+                .format(self.R, self.Z, self.current, self.turns, self.control))
+
+    def __eq__(self, other):
+        return (self.R == other.R
+                and self.Z == other.Z
+                and self.current == other.current
+                and self.turns == other.turns
+                and self.control == other.control)
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_tuple(self):
         """
@@ -210,12 +221,21 @@ class Circuit:
         for label, coil, multiplier in self.coils:
             result += multiplier * coil.controlBz(R, Z)
         return result
-        
+
     def __repr__(self):
-        result = "Circuit( " 
-        for label, coil, multiplier in self.coils:
-            result += label+ ":" + str(coil)+ " "
-        return result + ")"
+        result = "Circuit(["
+        coils = ['("{0}", {1}, {2})'.format(label, coil, multiplier)
+                 for label, coil, multiplier in self.coils]
+        result += ", ".join(coils)
+        return result + "], current={0}, control={1})".format(self.current, self.control)
+
+    def __eq__(self, other):
+        return (self.coils == other.coils
+                and self.current == other.current
+                and self.control == other.control)
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_tuple(self):
         """
@@ -314,7 +334,19 @@ class Solenoid:
         return result
 
     def __repr__(self):
-        return "Solenoid(R={0},Zmin={1},Zmax={2},current={3},N={4},control={5})".format(self.Rs, self.Zsmin, self.Zsmax, self.current, self.Ns, self.control)
+        return ("Solenoid(Rs={0}, Zsmin={1}, Zsmax={2}, current={3}, Ns={4}, control={5})"
+                .format(self.Rs, self.Zsmin, self.Zsmax, self.current, self.Ns, self.control))
+
+    def __eq__(self, other):
+        return (self.Rs == other.Rs
+                and self.Zsmin == other.Zsmin
+                and self.Zsmax == other.Zsmax
+                and self.Ns == other.Ns
+                and self.current == other.current
+                and self.control == other.control)
+
+    def __ne__(self, other):
+        return not self == other
 
     def to_tuple(self):
         """
@@ -331,6 +363,16 @@ class Wall:
     def __init__(self, R, Z):
         self.R = R
         self.Z = Z
+
+    def __repr__(self):
+        return "Wall(R={R}, Z={Z})".format(R=self.R, Z=self.Z)
+
+    def __eq__(self, other):
+        return (self.R == other.R
+                and self.Z == other.Z)
+
+    def __ne__(self, other):
+        return not self == other
     
     
 class Machine:
@@ -353,6 +395,19 @@ class Machine:
         
         self.coils = coils
         self.wall = wall
+
+    def __repr__(self):
+        return ("Machine(coils={coils}, wall={wall})"
+                .format(coils=self.coils, wall=self.wall))
+
+    def __eq__(self, other):
+        # Other Machine might be equivalent except for order of
+        # coils. Assume this doesn't actually matter
+        return (sorted(self.coils) == sorted(other.coils)
+                and self.wall == other.wall)
+
+    def __ne__(self, other):
+        return not self == other
 
     def __getitem__(self, name):
         for label, coil in self.coils:

--- a/test-03-write_read_equilibrium.py
+++ b/test-03-write_read_equilibrium.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import freegs
+
+from numpy import allclose
+from numpy.linalg import norm
+
+from sys import exit
+
+#########################################
+# Create the machine, which specifies coil locations
+# and equilibrium, specifying the domain to solve over
+
+tokamak = freegs.machine.MAST_sym()
+
+eq = freegs.Equilibrium(tokamak=tokamak,
+                        Rmin=0.1, Rmax=2.0,    # Radial domain
+                        Zmin=-1.0, Zmax=1.0,   # Height range
+                        nx=65, ny=65,          # Number of grid points
+                        boundary=freegs.boundary.freeBoundaryHagenow)  # Boundary condition
+
+
+#########################################
+# Plasma profiles
+
+profiles = freegs.jtor.ConstrainPaxisIp(1e4, # Plasma pressure on axis [Pascals]
+                                        1e6, # Plasma current [Amps]
+                                        2.0) # Vacuum f=R*Bt
+
+#########################################
+# Coil current constraints
+#
+# Specify locations of the X-points
+# to use to constrain coil currents
+
+xpoints = [(1.1, -0.6),   # (R,Z) locations of X-points
+           (1.1, 0.8)]
+
+isoflux = [(1.1,-0.6, 1.1,0.6)] # (R1,Z1, R2,Z2) pair of locations
+
+constrain = freegs.control.constrain(xpoints=xpoints, isoflux=isoflux)
+
+#########################################
+# Nonlinear solve
+
+freegs.solve(eq,          # The equilibrium to adjust
+             profiles,    # The toroidal current profile function
+             constrain)   # Constraint function to set coil currents
+
+with freegs.OutputFile("test_readwrite.h5", 'w') as f:
+    f.write_equilibrium(eq)
+
+with freegs.OutputFile("test_readwrite.h5", 'r') as f:
+    read_eq = f.read_equilibrium()
+
+print("\n---------------------------------------------")
+tokamaks_match = tokamak == read_eq.tokamak
+print("tokamaks match? ", tokamaks_match)
+psis_match = allclose(eq.psi(), read_eq.psi())
+print("psi() matches? ", psis_match)
+print("l2-norm of difference: ", norm(eq.psi() - read_eq.psi(), ord=2))
+
+if tokamaks_match and psis_match:
+    exit(0)
+else:
+    exit(1)


### PR DESCRIPTION
Add `OutputFile` for saving `Equilibrium` objects to HDF5 files using `h5py`.

Some slight annoyances:
- Puts a dependence on `h5py`. This should either be added to `install_requires` in setup.py, or check if it can be imported and if not disable `OutputFile`.
- The `dtype`s for the `Machine` components are in `dump.py`, but would be better in the classes themselves. Restoring the objects as well requires a hard-coded look-up. A better way might be to store the class name in the output file, and then call something like a `from_numpy` class method to create a new instance directly
- Should eventually be able to choose different file types, e.g. GEQDSK, DivGeo, TRANSP