### PR TITLE
Can now read SCENE output geqdsk

### DIFF
--- a/docs/input_and_output.rst
+++ b/docs/input_and_output.rst
@@ -52,6 +52,30 @@ This ``read`` function has the following stages:
 
 The ``show`` optional parameter displays a plot of the equilibrium, and shows the stages in the Grad-shafranov solve.
 
+Some options are:
+
+#. `domain = (Rmin, Rmax, Zmin, Zmax)` which can be used to specify
+   the (R,Z) domain to solve on. This is useful for reading inputs
+   from fixed boundary codes like SCENE, where the X-point(s) may lie
+   outside the domain. The coil current feedback needs to find where
+   the edge of the plasma is, so needs to find an X-point to work
+   correctly. The grid spacing is never allowed to increase, so this
+   may result in an increase in the number of grid points.
+#. `blend` is a number between 0 and 1, and is used in the nonlinear
+   Picard iteration. It determines what fraction of the previous
+   solution is used in the next solution. The default is 0, so no
+   blending is done. Adding blending (e.g. 0.5, 0.7) usually slows
+   convergence, but can stabilise oscillating or unstable solutions.
+#. `fit_sol` is `False` by default, so only points inside the
+   separatrix are used when fitting the coil currents to match the
+   input poloidal flux. This is useful in cases like reading SCENE
+   inputs, where the poloidal flux in the Scrape-Off Layer (SOL) is
+   not valid in the input. Setting `fit_sol=True` causes the whole
+   input domain to be used in the fitting. Currently this is NOT
+   compatible with setting a domain. It is useful when the locations
+   of strike points need to be matched, and may better constrain coil
+   currents for free boundary inputs (e.g. EFIT).
+
 Specifying coil currents
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/freegs/control.py
+++ b/freegs/control.py
@@ -176,21 +176,21 @@ class ConstrainPsi2D(object):
 
     Ignores constant offset differences between psi array
     """
-    def __init__(self, target_psi, weight=1.0):
+    def __init__(self, target_psi, weights=1.0):
         """
         target_psi : 2D (R,Z) array
             Must be the same size as the equilibrium psi
 
-        weight : float or 2D array of same size as target_psi
+        weights : float or 2D array of same size as target_psi
             Relative importance of each (R,Z) point in the fitting
             By default every point is equally weighted
             Set points to zero to ignore them in fitting.
            
         """
         # Remove the average so constant offsets are ignored
-        self.target_psi = target_psi - np.mean(target_psi)
+        self.target_psi = target_psi - np.average(target_psi, weights=weights)
         
-        self.weight = weight
+        self.weights = weights
         
     def __call__(self, eq):
         """
@@ -211,5 +211,5 @@ class ConstrainPsi2D(object):
         """
         eq.getMachine().setControlCurrents(currents)
         psi = eq.psi()
-        psi_av = np.mean(psi)
-        return ((psi - psi_av - self.target_psi)*self.weight).ravel() # flatten array
+        psi_av = np.average(psi, weights=self.weights)
+        return ((psi - psi_av - self.target_psi)*self.weights).ravel() # flatten array

--- a/freegs/critical.py
+++ b/freegs/critical.py
@@ -57,7 +57,13 @@ def find_critical(R, Z, psi,discard_xpoints=False):
     f = interpolate.RectBivariateSpline(R[:,0], Z[0,:], psi)
 
     # Find candidate locations, based on minimising Bp^2
-    Bp2 = (f(R,Z,dx=1,grid=False)**2 + f(R,Z,dy=1,grid=False)**2) / R
+    Bp2 = (f(R,Z,dx=1,grid=False)**2 + f(R,Z,dy=1,grid=False)**2) / R**2
+
+    # Get grid resolution, which determines a reasonable tolerance
+    # for the Newton iteration search area
+    dR = R[1,0] - R[0,0]
+    dZ = Z[0,1] - Z[0,0]
+    radius_sq = 9*(dR**2 + dZ**2)
     
     # Find local minima
 
@@ -91,8 +97,8 @@ def find_critical(R, Z, psi,discard_xpoints=False):
                 count = 0
                 while True:
                 
-                    Br = -f(R1, Z1, dy=1)[0][0]/R1
-                    Bz = f(R1, Z1, dx=1)[0][0]/R1
+                    Br = -f(R1, Z1, dy=1, grid=False)/R1
+                    Bz = f(R1, Z1, dx=1, grid=False)/R1
 
                     if Br**2 + Bz**2 < 1e-6:
                         # Found a minimum. Classify as either
@@ -156,7 +162,7 @@ def find_critical(R, Z, psi,discard_xpoints=False):
                     count += 1
                     # If (R1,Z1) is too far from (R0,Z0) then discard
                     # or if we've taken too many iterations
-                    if ((R1 - R0)**2 + (Z1 - Z0)**2 > 1e-2) or (count > 100):
+                    if ((R1 - R0)**2 + (Z1 - Z0)**2 > radius_sq) or (count > 100):
                         # Discard this point
                         break
     

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -246,7 +246,7 @@ class Equilibrium:
         """
         return array(find_separatrix(self, ntheta=ntheta, psi=self.psi()))[:, 0:2]
 
-    def solve(self, profiles, Jtor=None):
+    def solve(self, profiles, Jtor=None, psi=None):
         """
         Calculate the plasma equilibrium given new profiles
         replacing the current equilibrium.
@@ -270,7 +270,10 @@ class Equilibrium:
 
         if Jtor is None:
             # Calculate toroidal current density
-            Jtor = profiles.Jtor(self.R, self.Z, self.psi())
+
+            if psi is None:
+                psi = self.psi()
+            Jtor = profiles.Jtor(self.R, self.Z, psi)
         
         # Set plasma boundary
         # Note that the Equilibrium is passed to the boundary function

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -172,14 +172,14 @@ class Equilibrium:
         Radial magnetic field due to plasma
         Br = -1/R dpsi/dZ
         """
-        return -self.psi_func(R,Z,dy=1)[0][0]/R
+        return -self.psi_func(R,Z,dy=1, grid=False)/R
         
     def plasmaBz(self, R, Z):
         """
         Vertical magnetic field due to plasma 
         Bz = (1/R) dpsi/dR
         """
-        return self.psi_func(R,Z,dx=1)[0][0]/R
+        return self.psi_func(R,Z,dx=1, grid=False)/R
         
     def Br(self, R, Z):
         """

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -246,7 +246,7 @@ class Equilibrium:
         """
         return array(find_separatrix(self, ntheta=ntheta, psi=self.psi()))[:, 0:2]
 
-    def solve(self, profiles):
+    def solve(self, profiles, Jtor=None):
         """
         Calculate the plasma equilibrium given new profiles
         replacing the current equilibrium.
@@ -260,12 +260,17 @@ class Equilibrium:
              .ffprime(psinorm)
              .pressure(psinorm)
              .fpol(psinorm)
+
+        Jtor : 2D array
+            If supplied, specifies the toroidal current at each (R,Z) point
+            If not supplied, Jtor is calculated from profiles by finding O,X-points
         """
         
         self._profiles = profiles
-        
-        # Calculate toroidal current density
-        Jtor = profiles.Jtor(self.R, self.Z, self.psi())
+
+        if Jtor is None:
+            # Calculate toroidal current density
+            Jtor = profiles.Jtor(self.R, self.Z, self.psi())
         
         # Set plasma boundary
         # Note that the Equilibrium is passed to the boundary function
@@ -274,7 +279,7 @@ class Equilibrium:
         
         # Right hand side of G-S equation
         rhs = -mu0 * self.R * Jtor
-
+        
         # Copy boundary conditions
         rhs[0,:] = self.plasma_psi[0,:]
         rhs[:,0] = self.plasma_psi[:,0]

--- a/freegs/geqdsk.py
+++ b/freegs/geqdsk.py
@@ -357,7 +357,7 @@ def read(fh, machine, rtol=1e-3, ntheta=8, show=False, axis=None, cocos=1, domai
     picard.solve(eq,          # The equilibrium to adjust
                  profiles,    # The toroidal current profile function
                  controlsystem, show=show, axis=axis,
-                 rtol=rtol)
+                 rtol=rtol, blend=0.5)
     
     print("Plasma current: {0} Amps, input: {1} Amps".format(eq.plasmaCurrent(), data["cpasma"]))
     print("Plasma pressure on axis: {0} Pascals".format(eq.pressure(0.0)))

--- a/freegs/geqdsk.py
+++ b/freegs/geqdsk.py
@@ -351,6 +351,8 @@ def read(fh, machine, rtol=1e-3, ntheta=8, show=False, axis=None, cocos=1, domai
     # Refine the equilibrium to ensure consistency 
     # Solve using Picard iteration
     #
+
+    controlsystem = control.ConstrainPsiNorm2D(psi_norm, weights=mask)
     
     picard.solve(eq,          # The equilibrium to adjust
                  profiles,    # The toroidal current profile function

--- a/freegs/picard.py
+++ b/freegs/picard.py
@@ -80,15 +80,15 @@ def solve(eq, profiles, constrain=None, rtol=1e-3, blend=0.0,
         # Copy psi to compare at the end
         psi_last = psi.copy()
         
-        # Solve equilbrium
-        eq.solve(profiles)
+        # Solve equilbrium, using the given psi to calculate Jtor
+        eq.solve(profiles, psi=psi)
         
         # Get the new psi, including coils
         psi = eq.psi()
     
         # Compare against last solution
-        psi_last -= psi 
-        psi_maxchange = amax(abs(psi_last))
+        psi_change = psi_last - psi 
+        psi_maxchange = amax(abs(psi_change))
         psi_relchange = psi_maxchange/(amax(psi) - amin(psi))
         
         print("Maximum change in psi: %e. Relative: %e" % (psi_maxchange, psi_relchange))


### PR DESCRIPTION
Several small(ish) improvements needed to enable GEQDSK files from SCENE to be read, including

* Resizing of input grids to higher resolution
* Changing / extending of the input domain to include X-points
* Constraining of poloidal flux now ignores constant offsets due to different reference locations
* New control class ConstrainPsiNorm2D which constrains coil currents to match normalised psi
* Constraints can be applied using a masking/ weighting function. This can be used to avoid fitting to poloidal flux outside the separatrix in SCENE files, where the flux values are missing.
* The Picard iteration solution blending from one iteration to the next now works, and stabilises some cases
* Some documentation of the above
