### PR TITLE
fix write g-file

### DIFF
--- a/freegs/_fileutils.py
+++ b/freegs/_fileutils.py
@@ -62,7 +62,7 @@ def write_1d(val, out):
     """
     for i in range(len(val)):
         out.write(val[i])
-    out.endblock()
+    out.newline()
     
 
 def write_2d(val, out):
@@ -74,7 +74,7 @@ def write_2d(val, out):
     for y in range(ny):
         for x in range(nx):
             out.write(val[x,y])
-    out.endblock()
+    out.newline()
 
 def next_value(fh):
     """


### PR DESCRIPTION
The header now fallows the fix geqdsk file format.
uncomment workk, since with this commented is the file potentially buggy. 
replaced `endblock` with `newline`, since in special case, it can write two unwanted newlines. 

