### PR TITLE
Coil forces

### DIFF
--- a/01-freeboundary.py
+++ b/01-freeboundary.py
@@ -49,7 +49,11 @@ print("Done!")
 print("Plasma current: %e Amps" % (eq.plasmaCurrent()))
 print("Plasma pressure on axis: %e Pascals" % (eq.pressure(0.0)))
 
+# Currents in the coils
 tokamak.printCurrents()
+
+# Forces on the coils
+eq.printForces()
 
 ##############################################
 # Save to G-EQDSK file

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -320,6 +320,13 @@ class Equilibrium:
         from .plotting import plotEquilibrium
         return plotEquilibrium(self, axis=axis, show=show, oxpoints=oxpoints)
     
+    def getForces(self):
+        """
+        Calculate forces on the coils
+
+        Returns a dictionary of coil label -> force
+        """
+        return self.tokamak.getForces(self)
 
 def refine(eq):
     """

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -328,6 +328,20 @@ class Equilibrium:
         """
         return self.tokamak.getForces(self)
 
+    def printForces(self):
+        """
+        Prints a table of forces on coils
+        """
+        def print_forces(forces, prefix=""):
+            for label, force in forces.items():
+                if isinstance(force, dict):
+                    print(prefix + label + " (circuit)")
+                    print_forces(force, prefix=prefix + "  ")
+                else:
+                    print(prefix + label+ " : "  + str(force))
+
+        print_forces(self.getForces())
+
 def refine(eq):
     """
     Double grid resolution, returning a new equilibrium

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -332,13 +332,14 @@ class Equilibrium:
         """
         Prints a table of forces on coils
         """
+        print("Forces on coils")
         def print_forces(forces, prefix=""):
             for label, force in forces.items():
                 if isinstance(force, dict):
                     print(prefix + label + " (circuit)")
                     print_forces(force, prefix=prefix + "  ")
                 else:
-                    print(prefix + label+ " : "  + str(force))
+                    print(prefix + label+ " : R = {0:.2f} MN , Z = {1:.2f} MN".format(force[0]*1e-6, force[1]*1e-6))
 
         print_forces(self.getForces())
 

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -22,10 +22,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from .gradshafranov import Greens, GreensBr, GreensBz
+from .gradshafranov import Greens, GreensBr, GreensBz, mu0
 
 from numpy import linspace
 import numpy as np
+import numbers
 
 # We need this for the `label` part of the Circuit dtype for writing
 # to HDF5 files. See the following for information:
@@ -37,6 +38,28 @@ except ImportError:
     has_hdf5 = False
 
 
+class AreaCurrentLimit:
+    """
+    Calculate the coil area based on a fixed current density limit
+    """
+    def __init__(self, current_density = 3.5e9):
+        """
+        current_density   - Maximum current density in A/m^2
+        
+        Limits in general depend on the magnetic field
+        Typical values Nb3Sn ~ 3.5e9 A/m^2
+        https://doi.org/10.1016/0167-899X(86)90010-8
+        
+        """
+        self._current_density = current_density
+    
+    def __call__(self, coil):
+        """
+        Return the area in m^2, given a Coil object
+        """
+        return abs(coil.current * coil.turns) / self._current_density
+
+    
 class Coil:
     """
     Represents a poloidal field coil
@@ -45,9 +68,10 @@ class Coil:
     --------------
     
     R, Z - Location of the coil
-    current - current in the coil
+    current - current in the coil in Amps
     turns   - Number of turns
     control - enable or disable control system
+    area    - Cross-section area in m^2
 
     The total toroidal current carried by the coil is current * turns
     """
@@ -61,12 +85,26 @@ class Coil:
         (str("control"), np.bool),
     ])
 
-    def __init__(self, R, Z, current=0.0, turns=1, control=True):
+    def __init__(self, R, Z, current=0.0, turns=1, control=True, area=AreaCurrentLimit()):
         """
         R, Z - Location of the coil
         
-        current - current in the coil
+        current - current in each turn of the coil in Amps
+        turns   - Number of turns. Total coil current is current * turns
         control - enable or disable control system
+        area    - Cross-section area in m^2
+
+        Area can be a fixed value (e.g. 0.025 for 5x5cm coil), or can be specified
+        using a function which takes a coil as an input argument.
+        To specify a current density limit, use:
+      
+        area = AreaCurrentLimit(current_density)
+        
+        where current_density is in A/m^2. The area of the coil will be recalculated
+        as the coil current is changed.
+
+        The most important effect of the area is on the coil self-force:
+        The smaller the area the larger the hoop force for a given current.
         """
         self.R = R
         self.Z = Z
@@ -74,6 +112,7 @@ class Coil:
         self.current = current
         self.turns = turns
         self.control = control
+        self.area = area
 
     def psi(self, R, Z):
         """
@@ -137,7 +176,8 @@ class Coil:
             Physics of Plasmas 1, 3425 (1998); https://doi.org/10.1063/1.870491
             David A. Garren and James Chen
         """
-        current = self.current
+        current = self.current # current per turn
+        total_current = current * self.turns # Total toroidal current
 
         # Calculate field at this coil due to all other coils
         # and plasma. Need to zero this coil's current
@@ -146,11 +186,21 @@ class Coil:
         Bz = equilibrium.Bz(self.R, self.Z)
         self.current = current
 
-        ### NOTE: Need to add self-force
+        # Assume circular cross-section for hoop (self) force
+        minor_radius = np.sqrt(self.area / np.pi)
+        
+        # Self inductance factor, depending on internal current
+        # distribution. 0.5 for uniform current, 0 for surface current
+        self_inductance = 0.5
+
+        # Force per unit length.
+        # In cgs units f = I^2/(c^2 * R) * (ln(8*R/a) - 1 + xi/2)
+        # In SI units f = mu0 * I^2 / (4*pi*R) * (ln(8*R/a) - 1 + xi/2)
+        self_fr = (mu0 * total_current**2 / (4.*np.pi*self.R)) * (np.log(8.*self.R/minor_radius) - 1 + self_inductance/2.)
         
         Ltor = 2*np.pi*self.R  # Length of coil
-        return np.array([ current * Bz * Ltor, # Jphi x Bz = Fr
-                          -current * Br * Ltor]) # Jphi x Br = - Fz
+        return np.array([ (total_current * Bz  + self_fr) * Ltor, # Jphi x Bz = Fr, self force always outwards
+                          -total_current * Br * Ltor]) # Jphi x Br = - Fz
     
     def __repr__(self):
         return ("Coil(R={0}, Z={1}, current={2}, turns={3}, control={4})"
@@ -179,6 +229,23 @@ class Coil:
             raise ValueError("Can't create {this} from dtype: {got} (expected: {dtype})"
                              .format(this=type(cls), got=value.dtype, dtype=cls.dtype))
         return Coil(*value[()])
+
+    @property
+    def area(self):
+        """
+        The cross-section area of the coil in m^2
+        """
+        if isinstance(self._area, numbers.Number):
+            assert self._area > 0
+            return self._area
+        # Calculate using functor
+        area = self._area(self)
+        assert area > 0
+        return area
+    
+    @area.setter
+    def area(self, area):
+        self._area = area
 
 
 class Circuit:

--- a/freegs/test_machine.py
+++ b/freegs/test_machine.py
@@ -1,0 +1,75 @@
+#
+# Test calculation of magnetic field due to coils
+# and forces between coils
+
+from . import machine
+import numpy as np
+import math
+
+mu0 = 4e-7*np.pi
+
+def test_coil_axis():
+    """
+    Test magnetic field due to a single coil, on axis
+    """
+
+    Rcoil = 1.5
+    current = 123.
+    coil = machine.Coil(Rcoil, 1.0, current=current)
+
+    def analytic_Bz(dZ):
+        return (mu0/2)*Rcoil**2*current/(dZ**2 + Rcoil**2)**1.5
+
+    # Note: Can't evaluate at R=0, 
+    assert math.isclose(coil.Br(0.0001, 2.0), 0.0, abs_tol=1e-8)
+    assert math.isclose(coil.Bz(0.001, 2.0), analytic_Bz(1.0), abs_tol=1e-8)
+    assert math.isclose(coil.Bz(0.001, -1.0), analytic_Bz(-2.0), abs_tol=1e-8)
+    
+def test_coil_forces():
+    """
+    Test forces between two coils
+    """
+    Rcoil = 1.5
+    current = 123.
+
+    coil1 = machine.Coil(Rcoil, 1.0, current=current)
+    coil2 = machine.Coil(Rcoil, -1.0, current=current)
+    
+    tokamak = machine.Machine([("P1", coil1),
+                               ("P2", coil2)])
+    
+    forces = tokamak.getForces()
+
+    assert "P1" in forces and "P2" in forces
+
+    # Vertical force is equal and opposite
+    assert math.isclose( forces["P1"][1], -forces["P2"][1] )
+    assert forces["P1"][1] < 0.0  # Force downward towards other coil
+
+    # Reverse one of the currents
+    coil2.current = -123.0
+    # check the force reverses direction
+    forces = tokamak.getForces()
+    assert forces["P1"][1] > 0.0
+    
+    print(forces)
+    
+def test_coil_forces_unequal():
+    """
+    Test forces between two different sized coils
+    """
+
+    coil1 = machine.Coil(1.5, 1.0, current=123)
+    coil2 = machine.Coil(2.5, -1.0, current=456)
+    
+    tokamak = machine.Machine([("P1", coil1),
+                               ("P2", coil2)])
+    
+    forces = tokamak.getForces()
+
+    assert "P1" in forces and "P2" in forces
+
+    # Vertical force is equal and opposite
+    assert math.isclose( forces["P1"][1], -forces["P2"][1] )
+    assert forces["P1"][1] < 0.0  # Force downward towards other coil
+    


### PR DESCRIPTION
Calculates forces on each coil due to the other coils the plasma and itself. The self-force is the most tricky, and depends on the coil cross-section area. The default is currently to work out the coil cross-section area using a limit on the coil current density for Nb3Sn superconductor.

Since the forces depend on the plasma and coils, either:
```
eq.getForces()
```
or 
```
machine.getForces(eq)
```
A printing routine is also implemented for convenience:
```
eq.printForces()
```

Some simple tests and sanity checks are included using pytest.

WIP: Need to add documentation.