### PR TITLE
h5py was missing from venv build, so added h5py==2.10.0 to requiremen…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.14.1
 scipy>=1.0.0
 matplotlib>=2.0.0
+h5py==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     
     install_requires=['numpy>=1.8',
                       'scipy>=0.14',
-                      'matplotlib>=1.3'],
+                      'matplotlib>=1.3',
+                      'h5py==2.10.0'],
     
     platforms='any',
 


### PR DESCRIPTION
…ts.txt and setup.py

Hi All,

I just tried running test-03-write_read_equilibrium.py, and came up against an HDF5 error. The steps taken to get this error were:

```
┌─24-Feb 16:07:37 J0731 ~/builds 
└─$git clone https://github.com/bendudson/freegs.git
Cloning into 'freegs'...
cd remote: Enumerating objects: 269, done.
remote: Counting objects: 100% (269/269), done.
remote: Compressing objects: 100% (173/173), done.
Receiving objects:  62% (585/942), 564.01 KiB | 549.00 KiB/s   KiB/s   
remote: Total 942 (delta 165), reused 185 (delta 95), pack-reused 673
Receiving objects: 100% (942/942), 1.21 MiB | 587.00 KiB/s, done.
Resolving deltas: 100% (634/634), done.
                                                                              [ 3s615 | Feb 24 04:07pm ]
┌─24-Feb 16:07:42 J0731 ~/builds 
└─$cd freegs/
                                                                              [ 0s002 | Feb 24 04:07pm ]
┌─24-Feb 16:07:56 J0731 ~/builds/freegs 
└─$python3 -m venv env
                                                                              [ 0s944 | Feb 24 04:08pm ]
┌─24-Feb 16:08:00 J0731 ~/builds/freegs 
└─$source env/bin/activate
                                                                              [ 0s003 | Feb 24 04:08pm ]
(env) ┌─24-Feb 16:08:09 J0731 ~/builds/freegs 
└─$python setup.py install --user
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    import freegs
  File "/home/cookj/builds/freegs/freegs/__init__.py", line 33, in <module>
    from .equilibrium import Equilibrium
  File "/home/cookj/builds/freegs/freegs/equilibrium.py", line 8, in <module>
    from scipy import interpolate
ModuleNotFoundError: No module named 'scipy'
                                                                              [ 0s172 | Feb 24 04:08pm ]
(env) ┌─24-Feb 16:08:13 J0731 ~/builds/freegs 
└─$pip install -r requirements.txt 
Requirement already satisfied: numpy>=1.14.1 in /home/cookj/.local/lib/python3.6/site-packages (from -r requirements.txt (line 1))
Collecting scipy>=1.0.0 (from -r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/dc/29/162476fd44203116e7980cfbd9352eef9db37c49445d1fec35509022f6aa/scipy-1.4.1-cp36-cp36m-manylinux1_x86_64.whl
Collecting matplotlib>=2.0.0 (from -r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/7e/07/4b361d6d0f4e08942575f83a11d33f36897e1aae4279046606dd1808778a/matplotlib-3.1.3-cp36-cp36m-manylinux1_x86_64.whl
Collecting python-dateutil>=2.1 (from matplotlib>=2.0.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl
Collecting cycler>=0.10 (from matplotlib>=2.0.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/f7/d2/e07d3ebb2bd7af696440ce7e754c59dd546ffe1bbe732c8ab68b9c834e61/cycler-0.10.0-py2.py3-none-any.whl
Collecting pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 (from matplotlib>=2.0.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/5d/bc/1e58593167fade7b544bfe9502a26dc860940a79ab306e651e7f13be68c2/pyparsing-2.4.6-py2.py3-none-any.whl
Collecting kiwisolver>=1.0.1 (from matplotlib>=2.0.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/f8/a1/5742b56282449b1c0968197f63eae486eca2c35dcd334bab75ad524e0de1/kiwisolver-1.1.0-cp36-cp36m-manylinux1_x86_64.whl
Collecting six>=1.5 (from python-dateutil>=2.1->matplotlib>=2.0.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl
Requirement already satisfied: setuptools in /home/cookj/.local/lib/python3.6/site-packages (from kiwisolver>=1.0.1->matplotlib>=2.0.0->-r requirements.txt (line 3))
Installing collected packages: scipy, six, python-dateutil, cycler, pyparsing, kiwisolver, matplotlib
Successfully installed cycler-0.10.0 kiwisolver-1.1.0 matplotlib-3.1.3 pyparsing-2.4.6 python-dateutil-2.8.1 scipy-1.4.1 six-1.14.0
                                                                              [ 4s757 | Feb 24 04:08pm ]
(env) ┌─24-Feb 16:08:23 J0731 ~/builds/freegs 
└─$python setup.py install --user
running install
running bdist_egg
running egg_info
creating FreeGS.egg-info
writing FreeGS.egg-info/PKG-INFO
writing dependency_links to FreeGS.egg-info/dependency_links.txt
writing requirements to FreeGS.egg-info/requires.txt
writing top-level names to FreeGS.egg-info/top_level.txt
writing manifest file 'FreeGS.egg-info/SOURCES.txt'
reading manifest file 'FreeGS.egg-info/SOURCES.txt'
writing manifest file 'FreeGS.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib
creating build/lib/freegs
copying freegs/gradshafranov.py -> build/lib/freegs
copying freegs/test_polygons.py -> build/lib/freegs
copying freegs/multi_coil.py -> build/lib/freegs
copying freegs/test_multi_coil.py -> build/lib/freegs
copying freegs/equilibrium.py -> build/lib/freegs
copying freegs/test_optimise.py -> build/lib/freegs
copying freegs/optimiser.py -> build/lib/freegs
copying freegs/_fileutils.py -> build/lib/freegs
copying freegs/picard.py -> build/lib/freegs
copying freegs/geqdsk.py -> build/lib/freegs
copying freegs/jtor.py -> build/lib/freegs
copying freegs/divgeo.py -> build/lib/freegs
copying freegs/optimise.py -> build/lib/freegs
copying freegs/shaped_coil.py -> build/lib/freegs
copying freegs/test_shaped_coil.py -> build/lib/freegs
copying freegs/test_geqdsk.py -> build/lib/freegs
copying freegs/coil.py -> build/lib/freegs
copying freegs/critical.py -> build/lib/freegs
copying freegs/boundary.py -> build/lib/freegs
copying freegs/test_linearsolve.py -> build/lib/freegs
copying freegs/quadrature.py -> build/lib/freegs
copying freegs/control.py -> build/lib/freegs
copying freegs/multigrid.py -> build/lib/freegs
copying freegs/polygons.py -> build/lib/freegs
copying freegs/test_quadrature.py -> build/lib/freegs
copying freegs/plotting.py -> build/lib/freegs
copying freegs/test_machine.py -> build/lib/freegs
copying freegs/_geqdsk.py -> build/lib/freegs
copying freegs/dump.py -> build/lib/freegs
copying freegs/test_optimiser.py -> build/lib/freegs
copying freegs/_divgeo.py -> build/lib/freegs
copying freegs/__init__.py -> build/lib/freegs
copying freegs/test_fileutils.py -> build/lib/freegs
copying freegs/fieldtracer.py -> build/lib/freegs
copying freegs/test_jtor.py -> build/lib/freegs
copying freegs/machine.py -> build/lib/freegs
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/gradshafranov.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_polygons.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/multi_coil.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_multi_coil.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/equilibrium.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_optimise.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/optimiser.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/_fileutils.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/picard.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/geqdsk.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/jtor.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/divgeo.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/optimise.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/shaped_coil.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_shaped_coil.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_geqdsk.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/coil.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/critical.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/boundary.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_linearsolve.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/quadrature.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/control.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/multigrid.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/polygons.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_quadrature.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/plotting.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_machine.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/_geqdsk.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/dump.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_optimiser.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/_divgeo.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/__init__.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_fileutils.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/fieldtracer.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/test_jtor.py -> build/bdist.linux-x86_64/egg/freegs
copying build/lib/freegs/machine.py -> build/bdist.linux-x86_64/egg/freegs
byte-compiling build/bdist.linux-x86_64/egg/freegs/gradshafranov.py to gradshafranov.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_polygons.py to test_polygons.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/multi_coil.py to multi_coil.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_multi_coil.py to test_multi_coil.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/equilibrium.py to equilibrium.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_optimise.py to test_optimise.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/optimiser.py to optimiser.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/_fileutils.py to _fileutils.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/picard.py to picard.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/geqdsk.py to geqdsk.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/jtor.py to jtor.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/divgeo.py to divgeo.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/optimise.py to optimise.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/shaped_coil.py to shaped_coil.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_shaped_coil.py to test_shaped_coil.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_geqdsk.py to test_geqdsk.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/coil.py to coil.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/critical.py to critical.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/boundary.py to boundary.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_linearsolve.py to test_linearsolve.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/quadrature.py to quadrature.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/control.py to control.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/multigrid.py to multigrid.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/polygons.py to polygons.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_quadrature.py to test_quadrature.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/plotting.py to plotting.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_machine.py to test_machine.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/_geqdsk.py to _geqdsk.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/dump.py to dump.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_optimiser.py to test_optimiser.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/_divgeo.py to _divgeo.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/__init__.py to __init__.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_fileutils.py to test_fileutils.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/fieldtracer.py to fieldtracer.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/test_jtor.py to test_jtor.cpython-36.pyc
byte-compiling build/bdist.linux-x86_64/egg/freegs/machine.py to machine.cpython-36.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying FreeGS.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying FreeGS.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying FreeGS.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying FreeGS.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying FreeGS.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist/FreeGS-0.4.0-py3.6.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing FreeGS-0.4.0-py3.6.egg
Removing /home/cookj/.local/lib/python3.6/site-packages/FreeGS-0.4.0-py3.6.egg
Copying FreeGS-0.4.0-py3.6.egg to /home/cookj/.local/lib/python3.6/site-packages
FreeGS 0.4.0 is already the active version in easy-install.pth

Installed /home/cookj/.local/lib/python3.6/site-packages/FreeGS-0.4.0-py3.6.egg
Processing dependencies for FreeGS==0.4.0
Searching for matplotlib==3.1.3
Best match: matplotlib 3.1.3
Adding matplotlib 3.1.3 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for scipy==1.4.1
Best match: scipy 1.4.1
Adding scipy 1.4.1 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for numpy==1.17.4
Best match: numpy 1.17.4
Adding numpy 1.17.4 to easy-install.pth file
Installing f2py script to /home/cookj/.local/bin
Installing f2py3 script to /home/cookj/.local/bin
Installing f2py3.6 script to /home/cookj/.local/bin

Using /home/cookj/.local/lib/python3.6/site-packages
Searching for cycler==0.10.0
Best match: cycler 0.10.0
Adding cycler 0.10.0 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for kiwisolver==1.1.0
Best match: kiwisolver 1.1.0
Adding kiwisolver 1.1.0 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for python-dateutil==2.8.1
Best match: python-dateutil 2.8.1
Adding python-dateutil 2.8.1 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for pyparsing==2.4.6
Best match: pyparsing 2.4.6
Adding pyparsing 2.4.6 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for six==1.14.0
Best match: six 1.14.0
Adding six 1.14.0 to easy-install.pth file

Using /home/cookj/builds/freegs/env/lib/python3.6/site-packages
Searching for setuptools==41.1.0
Best match: setuptools 41.1.0
Adding setuptools 41.1.0 to easy-install.pth file
Installing easy_install script to /home/cookj/.local/bin
Installing easy_install-3.6 script to /home/cookj/.local/bin

Using /home/cookj/.local/lib/python3.6/site-packages
Finished processing dependencies for FreeGS==0.4.0
                                                                              [ 0s430 | Feb 24 04:08pm ]
(env) ┌─24-Feb 16:08:26 J0731 ~/builds/freegs 
└─$python test-03-write_read_equilibrium.py 
Traceback (most recent call last):
  File "test-03-write_read_equilibrium.py", line 50, in <module>
    with freegs.OutputFile("test_readwrite.h5", 'w') as f:
  File "/home/cookj/builds/freegs/freegs/dump.py", line 91, in __init__
    raise OutputFormatNotAvailableError("HDF5")
freegs.dump.OutputFormatNotAvailableError: HDF5
                                                                              [ 3s218 | Feb 24 04:08pm ]
```

Repeating the above steps but on this branch with the fix, the last command gives:

```
(env) ┌─24-Feb 16:22:04 J0731 ~/builds/freegs 
└─$python test-03-write_read_equilibrium.py 
/home/cookj/builds/freegs/freegs/dump.py:140: H5pyDeprecationWarning: other_ds.dims.create_scale(ds, name) is deprecated. Use ds.make_scale(name) instead.
  psi_id.dims.create_scale(equilibrium_group["R_1D"], "R")
/home/cookj/builds/freegs/freegs/dump.py:141: H5pyDeprecationWarning: other_ds.dims.create_scale(ds, name) is deprecated. Use ds.make_scale(name) instead.
  psi_id.dims.create_scale(equilibrium_group["Z_1D"], "Z")

---------------------------------------------
tokamaks match?  True
psi() matches?  True
l2-norm of difference:  4.790071934451025e-15
                                                                              [ 3s767 | Feb 24 04:22pm ]
```

