### PR TITLE
Boundary resolution

### DIFF
--- a/freegs/critical.py
+++ b/freegs/critical.py
@@ -382,6 +382,7 @@ def find_separatrix(eq, opoint=None, xpoint=None, ntheta=20, psi=None, axis=None
 
     # Avoid putting theta grid points exactly on the X-points
     xpoint_theta = arctan2(xpoint[0][0] - r0, xpoint[0][1] - z0)
+    xpoint_theta = xpoint_theta * (xpoint_theta >= 0) + (xpoint_theta + 2 * pi) * (xpoint_theta < 0)
     # How close in theta to allow theta grid points to the X-point
     TOLERANCE = 1.e-3
     if any(abs(theta_grid - xpoint_theta) < TOLERANCE):

--- a/freegs/critical.py
+++ b/freegs/critical.py
@@ -394,7 +394,8 @@ def find_separatrix(eq, opoint=None, xpoint=None, ntheta=20, psi=None, axis=None
                                r0, z0,
                                r0 + 10.*sin(theta), z0 + 10.*cos(theta),
                                psival=psival,
-                               axis=axis)
+                               axis=axis,
+                               n=1000)
         isoflux.append((r, z, xpoint[0][0], xpoint[0][1]))
 
     return isoflux

--- a/freegs/critical.py
+++ b/freegs/critical.py
@@ -382,7 +382,7 @@ def find_separatrix(eq, opoint=None, xpoint=None, ntheta=20, psi=None, axis=None
 
     # Avoid putting theta grid points exactly on the X-points
     xpoint_theta = arctan2(xpoint[0][0] - r0, xpoint[0][1] - z0)
-    xpoint_theta = xpoint_theta * (xpoint_theta >= 0) + (xpoint_theta + 2 * pi) * (xpoint_theta < 0)
+    xpoint_theta = xpoint_theta * (xpoint_theta >= 0) + (xpoint_theta + 2 * pi) * (xpoint_theta < 0) #let's make it between 0 and 2*pi
     # How close in theta to allow theta grid points to the X-point
     TOLERANCE = 1.e-3
     if any(abs(theta_grid - xpoint_theta) < TOLERANCE):
@@ -439,6 +439,7 @@ def find_safety(eq, npsi=1, psinorm=None, ntheta=128, psi=None, opoint=None, xpo
     
      # Avoid putting theta grid points exactly on the X-points
     xpoint_theta = arctan2(xpoint[0][0] - r0, xpoint[0][1] - z0)
+    xpoint_theta = xpoint_theta * (xpoint_theta >= 0) + (xpoint_theta + 2 * pi) * (xpoint_theta < 0) #let's make it between 0 and 2*pi
     # How close in theta to allow theta grid points to the X-point
     TOLERANCE = 1.e-3
     


### PR DESCRIPTION
With this pull request I increase the resolution to find the separatrix (`n=1000` instead of `n=100`), and I add a line of code to convert the x-point theta from `[-pi,pi]` (standard output of `arctan2` in `numpy`) to `[0,2pi]`, since the tolerance check occurs with respect to the `theta_grid`, which is defined from `[0,2pi]`.