### PR TITLE
Modify the float pattern matching in fileutils

### DIFF
--- a/freegs/_fileutils.py
+++ b/freegs/_fileutils.py
@@ -110,7 +110,7 @@ def next_value(fh):
     the correct type depending on if '.' is in the string
     
     """
-    pattern = re.compile(r'[ +\-]?\d+(?:\.\d+[Ee][\+\-]\d\d)?')
+    pattern = re.compile(r"[ +\-]?\d+(?:\.\d+(?:[Ee][\+\-]\d\d)?)?")
 
     # Go through each line, extract values, then yield them one by one
     for line in fh:


### PR DESCRIPTION
When reading a GEQDSK file, match floats separated by spaces e.g. `12 34 1.1234 0 0`

Thanks to @kripnerl !

closes #43 