### PR TITLE
HDF5 improvements

### DIFF
--- a/freegs/coil.py
+++ b/freegs/coil.py
@@ -74,8 +74,8 @@ class Coil:
             (str("R"), np.float64),
             (str("Z"), np.float64),
             (str("current"), np.float64),
-            (str("turns"), np.int),
-            (str("control"), np.bool),
+            (str("turns"), int),
+            (str("control"), bool),
         ]
     )
 

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -214,10 +214,21 @@ class Circuit:
                     this=type(cls), got=value.dtype, dtype=cls.dtype
                 )
             )
+
+        # HDF5 reads strings as bytes by default, so convert to string
+        def toString(s):
+            try:
+                return str(s, "utf-8")  # Convert bytes to string, using encoding
+            except TypeError:
+                return s  # Probably already a string
+
         # Use the current/control values from the first coil in the circuit
         # Should be consistent!
         return Circuit(
-            [(label, Coil(*coil), multiplier) for label, coil, multiplier in value],
+            [
+                (toString(label), Coil(*coil), multiplier)
+                for label, coil, multiplier in value
+            ],
             current=value[0][1]["current"] / value[0]["multiplier"],
             control=value[0][1]["control"],
         )
@@ -424,7 +435,7 @@ class Wall:
         return "Wall(R={R}, Z={Z})".format(R=self.R, Z=self.Z)
 
     def __eq__(self, other):
-        return self.R == other.R and self.Z == other.Z
+        return np.allclose(self.R, other.R) and np.allclose(self.Z, other.Z)
 
     def __ne__(self, other):
         return not self == other

--- a/freegs/test_readwrite.py
+++ b/freegs/test_readwrite.py
@@ -6,35 +6,37 @@ from numpy import allclose
 
 def test_readwrite():
     """Test reading/writing to a file round-trip"""
-    tokamak = freegs.machine.MAST_sym()
-    eq = freegs.Equilibrium(
-        tokamak=tokamak,
-        Rmin=0.1,
-        Rmax=2.0,
-        Zmin=-1.0,
-        Zmax=1.0,
-        nx=17,
-        ny=17,
-        boundary=freegs.boundary.freeBoundaryHagenow,
-    )
-    profiles = freegs.jtor.ConstrainPaxisIp(1e4, 1e6, 2.0)
 
-    # Note here the X-point locations and isoflux locations are not the same.
-    # The result will be an unbalanced double null configuration, where the
-    # X-points are on different flux surfaces.
-    xpoints = [(1.1, -0.6), (1.1, 0.8)]
-    isoflux = [(1.1, -0.6, 1.1, 0.6)]
-    constrain = freegs.control.constrain(xpoints=xpoints, isoflux=isoflux)
+    for tokamak in [freegs.machine.TestTokamak(), freegs.machine.MAST_sym()]:
 
-    freegs.solve(eq, profiles, constrain, maxits=25, atol=1e-3, rtol=1e-1)
+        eq = freegs.Equilibrium(
+            tokamak=tokamak,
+            Rmin=0.1,
+            Rmax=2.0,
+            Zmin=-1.0,
+            Zmax=1.0,
+            nx=17,
+            ny=17,
+            boundary=freegs.boundary.freeBoundaryHagenow,
+        )
+        profiles = freegs.jtor.ConstrainPaxisIp(1e4, 1e6, 2.0)
 
-    memory_file = io.BytesIO()
+        # Note here the X-point locations and isoflux locations are not the same.
+        # The result will be an unbalanced double null configuration, where the
+        # X-points are on different flux surfaces.
+        xpoints = [(1.1, -0.6), (1.1, 0.8)]
+        isoflux = [(1.1, -0.6, 1.1, 0.6)]
+        constrain = freegs.control.constrain(xpoints=xpoints, isoflux=isoflux)
 
-    with freegs.OutputFile(memory_file, "w") as f:
-        f.write_equilibrium(eq)
+        freegs.solve(eq, profiles, constrain, maxits=25, atol=1e-3, rtol=1e-1)
 
-    with freegs.OutputFile(memory_file, "r") as f:
-        read_eq = f.read_equilibrium()
+        memory_file = io.BytesIO()
 
-    assert tokamak == read_eq.tokamak
-    assert allclose(eq.psi(), read_eq.psi())
+        with freegs.OutputFile(memory_file, "w") as f:
+            f.write_equilibrium(eq)
+
+        with freegs.OutputFile(memory_file, "r") as f:
+            read_eq = f.read_equilibrium()
+
+        assert tokamak == read_eq.tokamak
+        assert allclose(eq.psi(), read_eq.psi())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.14.1
 scipy>=1.0.0
 matplotlib>=2.0.0
-h5py==2.10.0
+h5py>=2.10.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=['numpy>=1.8',
                       'scipy>=0.14',
                       'matplotlib>=1.3',
-                      'h5py==2.10.0'],
+                      'h5py>=2.10.0'],
     
     platforms='any',
 


### PR DESCRIPTION
- Add to_numpy_array and from_numpy_array to ShapedCoil and MultiCoil
- HDF5 reads strings as bytes, which then are not equal to strings
  Now convert labels to strings
- Check if arrays are similar with `numpy.allclose`
- Use int and bool rather than np.int and np.bool (NumPy deprecated)
-  Allow later versions of h5py. Tested with 3.1.0

Unfortunately Circuits cause trouble because the coils they contain might be different, so can't be (easily) represented as an array of coils.