### PR TITLE
Geqdsk read fixes

### DIFF
--- a/freegs/__init__.py
+++ b/freegs/__init__.py
@@ -42,3 +42,5 @@ from . import control
 from .picard import solve
 
 from .dump import OutputFile
+
+from . import plotting

--- a/freegs/control.py
+++ b/freegs/control.py
@@ -190,7 +190,7 @@ class ConstrainPsi2D(object):
     Ignores constant offset differences between psi array
     """
 
-    def __init__(self, target_psi, weights=1.0):
+    def __init__(self, target_psi, weights=None):
         """
         target_psi : 2D (R,Z) array
             Must be the same size as the equilibrium psi
@@ -201,6 +201,9 @@ class ConstrainPsi2D(object):
             Set points to zero to ignore them in fitting.
 
         """
+        if weights is None:
+            weights = np.full(target_psi.shape, 1.0)
+
         # Remove the average so constant offsets are ignored
         self.target_psi = target_psi - np.average(target_psi, weights=weights)
 

--- a/freegs/control.py
+++ b/freegs/control.py
@@ -283,10 +283,15 @@ class ConstrainPsiNorm2D(object):
 
         opt, xpt = critical.find_critical(eq.R, eq.Z, psi)
         if not opt:
+            print("No O-points found!")
+            print(opt, xpt)
+            eq.plot()
             raise ValueError("No O-points found!")
         psi_axis = opt[0][2]
 
         if not xpt:
+            print("No X-points found!")
+            eq.plot()
             raise ValueError("No X-points found")
         psi_bndry = xpt[0][2]
 


### PR DESCRIPTION
Main improvement is to change how the core mask is calculated when reading GEQDSK files, which affects how the initial current distribution is calculated. The previous implementation was too simple, and resulted in currents in the private flux region.
The new code uses the same method as is used in the main solve.