### PR TITLE
Calculation force on each filament in MultiCoil separtely. 

### DIFF
--- a/freegs/_forces.py
+++ b/freegs/_forces.py
@@ -1,3 +1,5 @@
+from numbers import Number
+
 from .gradshafranov import mu0
 import numpy as np
 
@@ -19,10 +21,12 @@ def getForces(Rs, Zs, coil, equilibrium):
     current = coil.current  # current per turn
 
     # Calculated coil force or force acting on each element.
-    if len(Rs) > 1:
-        total_current = current
-    else:
+    if isinstance(Rs, Number) or (hasattr(Rs, '__len__') and len(Rs) == 1):
         total_current = current * coil.turns  # Total toroidal current
+    elif not hasattr(Rs, '__len__'):
+        return TypeError("The Rs and Zs should be either arrays or numbers.")
+    else:
+        total_current = current
 
     # Calculate field at this coil due to all other coils
     # and plasma. Need to zero this coil's current

--- a/freegs/_forces.py
+++ b/freegs/_forces.py
@@ -1,0 +1,55 @@
+from .gradshafranov import mu0
+import numpy as np
+
+def getForces(Rs, Zs, coil, equilibrium):
+    """
+    Calculate forces on the coils in Newtons.
+
+    Rs: float or array - radial position where the force is evaluated
+    Zs: float or array - vertical position where the force is evaluated
+
+    Returns an array of two elements or arrays: [ Fr, Fz ]
+
+
+    Force on coil due to its own current:
+        Lorentz self‐forces on curved current loops
+        Physics of Plasmas 1, 3425 (1998); https://doi.org/10.1063/1.870491
+        David A. Garren and James Chen
+    """
+    current = coil.current  # current per turn
+
+    # Calculated coil force or force acting on each element.
+    if len(Rs) > 1:
+        total_current = current
+    else:
+        total_current = current * coil.turns  # Total toroidal current
+
+    # Calculate field at this coil due to all other coils
+    # and plasma. Need to zero this coil's current
+    coil.current = 0.0
+    Br = equilibrium.Br(Rs, Zs)
+    Bz = equilibrium.Bz(Rs, Zs)
+    coil.current = current
+
+    # Assume circular cross-section for hoop (coil) force
+    minor_radius = np.sqrt(coil.area / np.pi)
+
+    # coil inductance factor, depending on internal current
+    # distribution. 0.5 for uniform current, 0 for surface current
+    coil_inductance = 0.5
+
+    # Force per unit length.
+    # In cgs units f = I^2/(c^2 * R) * (ln(8*R/a) - 1 + xi/2)
+    # In SI units f = mu0 * I^2 / (4*pi*R) * (ln(8*R/a) - 1 + xi/2)
+    coil_fr = (mu0 * total_current ** 2 / (4.0 * np.pi * Rs)) * (
+            np.log(8.0 * Rs / minor_radius) - 1 + coil_inductance / 2.0
+    )
+
+    Ltor = 2 * np.pi * coil.R  # Length of coil
+    return np.array(
+        [
+            (total_current * Bz + coil_fr)
+            * Ltor,  # Jphi x Bz = Fr, coil force always outwards
+            -total_current * Br * Ltor,
+        ]
+    )  # Jphi x Br = - Fz

--- a/freegs/machine.py
+++ b/freegs/machine.py
@@ -587,6 +587,24 @@ class Machine:
             print(label + " : " + str(coil))
         print("==========================")
 
+    def getCentreForces(self, equilibrium=None):
+        """
+        Calculate forces on the coils, given the plasma equilibrium.
+        If no plasma equilibrium given then the forces due to
+        the coils alone will be calculated.
+
+        The force calculated with respect to the centre of each coil.
+
+        Returns a dictionary of coil label -> force
+        """
+        if equilibrium is None:
+            equilibrium = self
+
+        forces = {}
+        for label, coil in self.coils:
+            forces[label] = coil.getCentreForces(equilibrium)
+        return forces
+
     def getForces(self, equilibrium=None):
         """
         Calculate forces on the coils, given the plasma equilibrium.

--- a/freegs/multi_coil.py
+++ b/freegs/multi_coil.py
@@ -25,7 +25,7 @@ along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from .coil import Coil, AreaCurrentLimit
 from .gradshafranov import Greens, GreensBr, GreensBz
-
+from freegs._forces import getForces
 
 class MultiCoil(Coil):
     """
@@ -140,6 +140,39 @@ class MultiCoil(Coil):
             for R_fil, Z_fil in zip(self.Rfil, self.Zfil):
                 result += Greens(R_fil, -Z_fil, R, Z) * self.polarity[1]
         return result
+
+    def getCentreForces(self, equilibrium):
+        """
+        Calculate force acting on the coil calculated with respect to its centre.
+
+        Return
+        ------
+        array [ Fr, Fz ] Radial (hoop) and vertical force.
+        """
+        return super(MultiCoil, self).getForces(equilibrium)
+
+    def getForces(self, equilibrium):
+        """
+        Calculate total force acting on the coil.
+
+        Return
+        ------
+        array [ Fr, Fz ] Radial (hoop) and vertical force.
+        """
+        fil_forces = self.getFilamentForces(equilibrium)
+        mean_forces = np.sum(fil_forces, axis=1)
+
+        return mean_forces
+
+    def getFilamentForces(self, equilibrium):
+        """
+        Calculate force acting on each coil filament separately.
+
+        Return
+        ------
+        array [ Fr: array, Fz: array) ] - Arrays of radial (hoop) and vertical forces.
+        """
+        return getForces(self.Rfil, self.Zfil, self, equilibrium)
 
     def controlBr(self, R, Z):
         """


### PR DESCRIPTION
## Motivation
The precision of calculation of vertical force of coils which are close together appeared to be imprecise. Please see the figure below. In the first case (blue) the coils are represented by the `Coil` class. In the other two cases, the coils are represented by filaments. The force in orange is calculated by default implementation and the new implementation is represented by the green colour. 

## Changelog: 
* add force calculation of `MultiCoil` in `multi_coil.py` in getFilamen…
* add getCentreForces method for simplified calculation of the forces.
* todo: is the current implementation of self coil hoop force
* add `_forces.py` helper package 

![obrazek](https://user-images.githubusercontent.com/38673295/109843765-b706ce00-7c4b-11eb-9d97-64cbdea353d3.png)
