### PR TITLE
Coil current limits

### DIFF
--- a/01-freeboundary.py
+++ b/01-freeboundary.py
@@ -33,14 +33,18 @@ xpoints = [(1.1, -0.6),   # (R,Z) locations of X-points
 
 isoflux = [(1.1,-0.6, 1.1,0.6)] # (R1,Z1, R2,Z2) pair of locations
 
-constrain = freegs.control.constrain(xpoints=xpoints, isoflux=isoflux)
+current_lims = [(-150000.0,140000.0),(0.0,65000.0),(-105000.0,0.0),(-60000.0,0.0)]
+total_current = 350000.0
+
+constrain = freegs.control.constrain(xpoints=xpoints, isoflux=isoflux, current_lims=current_lims, max_total_current = total_current)
 
 #########################################
 # Nonlinear solve
 
 freegs.solve(eq,          # The equilibrium to adjust
              profiles,    # The toroidal current profile function
-             constrain)   # Constraint function to set coil currents
+             constrain,
+             show=True)   # Constraint function to set coil currents
 
 # eq now contains the solution
 

--- a/freegs/control.py
+++ b/freegs/control.py
@@ -4,16 +4,10 @@ Plasma control system
 Use constraints to adjust coil currents
 """
 
-from ipaddress import summarize_address_range
-from shutil import register_unpack_format
 from numpy import dot, transpose, eye, array, inf
 from numpy.linalg import inv, norm
 import numpy as np
-
 from scipy import optimize
-import scipy
-from sqlalchemy import BLANK_SCHEMA
-
 from . import critical
 
 


### PR DESCRIPTION
Added the ability for the user to specify upper and lower bounds on coil currents, as well as on the total current across all coils. Uses analytical current solution to guide the solver. Example shown in 01-free-boundary.py